### PR TITLE
Develop Initial GitHub Webhook Controller tests

### DIFF
--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -4,6 +4,7 @@ class WebhookController < ApplicationController
     def handle_payload
         @payload = params[:payload]
         @payload_body = request.body.read
+        @time_now = Time.now.getutc
 
         # Make sure that this hook came from a known repo
         verify_signature(@payload_body)
@@ -11,23 +12,23 @@ class WebhookController < ApplicationController
         case request.env['HTTP_X_GITHUB_EVENT']
             when "pull_request"
                 if @payload["action"] == "opened"
-                    puts "WHC Received: pull_request[opened]"
+                    puts "#{@time_now} WHC Received: pull_request[opened]"
                 elsif @payload["action"] == "synchronized"
-                    puts "WHC Received: pull_request[synchronized]"
+                    puts "#{@time_now} WHC Received: pull_request[synchronized]"
                 elsif @payload["action"] == "closed"
-                    puts "WHC Received: pull_request[closed]"
+                    puts "#{@time_now} WHC Received: pull_request[closed]"
                 elsif @payload["action"] == "reopened"
-                    puts "WHC Received: pull_request[reopened]"
+                    puts "#{@time_now} WHC Received: pull_request[reopened]"
                 else
-                    puts "WHC Received: pull_request[Unknown action]"
+                    puts "#{@time_now} WHC Received: pull_request[Unknown action]"
                 end
             when "issue_comment"
-                puts "WHC Received: issue_comment"
+                puts "#{@time_now} WHC Received: issue_comment"
             when "ping"
-                puts "WHC Received: ping"
+                puts "#{@time_now} WHC Received: ping"
                 # Send initial status message so Protected Branch can be setup
             else
-                puts "WHC Received: Unknown Event"
+                puts "#{@time_now} WHC Received: Unknown Event"
                 # Should this be an error? Got something we don't know how to handle
         end
         # For now don't send anything in body of message.

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -3,33 +3,36 @@ class WebhookController < ApplicationController
 
     def handle_payload
         @payload = params[:payload]
+        @payload_body = request.body.read
 
         # Make sure that this hook came from a known repo
-        verify_signature(request.body.read)
+        verify_signature(@payload_body)
 
         case request.env['HTTP_X_GITHUB_EVENT']
             when "pull_request"
                 if @payload["action"] == "opened"
-                    puts "Received: pull_request[opened]"
+                    puts "WHC Received: pull_request[opened]"
                 elsif @payload["action"] == "synchronized"
-                    puts "Received: pull_request[synchronized]"
+                    puts "WHC Received: pull_request[synchronized]"
                 elsif @payload["action"] == "closed"
-                    puts "Received: pull_request[closed]"
+                    puts "WHC Received: pull_request[closed]"
                 elsif @payload["action"] == "reopened"
-                    puts "Received: pull_request[reopened]"
+                    puts "WHC Received: pull_request[reopened]"
+                else
+                    puts "WHC Received: pull_request[Unknown action]"
                 end
             when "issue_comment"
-                puts "Received: issue_comment"
+                puts "WHC Received: issue_comment"
             when "ping"
-                puts "Received: ping"
+                puts "WHC Received: ping"
                 # Send initial status message so Protected Branch can be setup
             else
-                puts "Received: Unknown Event"
+                puts "WHC Received: Unknown Event"
                 # Should this be an error? Got something we don't know how to handle
         end
         # For now don't send anything in body of message.
         # In future might add status message here
-        render :nothing => true
+        render plain: "Received #{request.env['HTTP_X_GITHUB_EVENT']} Event"
     end
 
     def verify_signature(payload_body)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,5 @@
 Rails.application.routes.draw do
 
     # Add target for where to direct WebHook traffic
-    scope '/webhook', :controller => :webhook do
-        post :handle_payload
-    end
+    post '/wehook', to: 'webhook#handle_payload'
 end

--- a/test/controllers/webhook_controller_test.rb
+++ b/test/controllers/webhook_controller_test.rb
@@ -1,7 +1,44 @@
 require 'test_helper'
 
 class WebhookControllerTest < ActionController::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+    test 'webhook events' do
+        # Test all the basic events
+        [:issue_comment, :ping, :unknown].each do |e|
+            send_payload(e)
+        end
+    end
+
+    test 'pull request actions' do
+        # Test the various pull_request actions
+        [:opened, :synchronized, :closed, :reopened, :unknown].each do |a|
+            # As more functionality is written add to this param block
+            t_payload = {action: a}
+            send_payload(:pull_request, t_payload)
+        end
+    end
+
+    private
+    def send_payload(e_type, event_payload={})
+        # Set the event type
+        @request.headers['HTTP_X_GITHUB_EVENT'] = e_type.to_s
+
+        # Generate the payload body and the sha1 signature
+        payload_body = {payload: event_payload}
+        gen_signature(payload_body)
+
+        # Send the actual message
+        post(:handle_payload, payload_body)
+
+        # Check the response to make sure got okay
+        assert_response(:success, "#{e_type} didn't receive 200 status")
+        # Check that the body message matches
+        assert_equal(@response.body, "Received #{e_type} Event")
+    end
+
+    def gen_signature(payload_body)
+        signature = 'sha1=' + OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha1'),
+                                                      ENV['WEBHOOK_SECRET_KEY'],
+                                                      payload_body.to_query)
+        @request.headers['HTTP_X_HUB_SIGNATURE'] = signature
+    end
 end


### PR DESCRIPTION
Put together basic test driver to send WebHook messages without requiring GitHub.