### PR TITLE
Setup Automated Testing in Travis.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 /tmp
 .DS_Store
 db/*.sqlite3
+/vendor

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,4 @@ before_script:
 sudo: false
 notifications:
   email: false
+cache: bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: ruby
 rvm:
-    - 2.3
     - 2.2
 services:
     - postgresql
 before_script:
-    - rake db:setup
+    - bundle exec rake db:setup
 sudo: false
 notifications:
   emails: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: ruby
+rvm:
+    - 2.3
+    - 2.2
+services:
+    - postgresql
+before_script:
+    - rake db:setup
+sudo: false
+notifications:
+  emails: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ before_script:
     - bundle exec rake db:setup
 sudo: false
 notifications:
-  emails: false
+  email: false

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -12,7 +12,7 @@ class WebhookController < ApplicationController
 
         # Make sure that this hook came from a known repo
         repo = Repository.find_by(ghid: @payload["repository"]["id"])
-        return render(plaib: "Repository not found", status: :not_found) if repo == nil
+        return render(plain: "Repository not found", status: :not_found) if repo == nil
         WebhookHelper.verify_signature(repo.secret_key, @payload_body, request.env['HTTP_X_HUB_SIGNATURE'])
 
         case request.env['HTTP_X_GITHUB_EVENT']

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -2,29 +2,42 @@ class WebhookController < ApplicationController
     skip_before_action :verify_authenticity_token
 
     def handle_payload
+        # The following is a 'band-aid' to make testing and production work. The
+        # requests from GitHub come in as a string, but requests from tests come
+        # in as a ActionController::Parameters hash. So only call JSON.parse the
+        # parameters if they are a string.
         @payload = params[:payload]
+        @payload = JSON.parse(params[:payload]) if @payload.is_a?(String)
         @payload_body = request.body.read
 
         # Make sure that this hook came from a known repo
-        verify_signature(@payload_body)
+        repo = Repository.find_by(ghid: @payload["repository"]["id"])
+        return render(plaib: "Repository not found", status: :not_found) if repo == nil
+        WebhookHelper.verify_signature(repo.secret_key, @payload_body, request.env['HTTP_X_HUB_SIGNATURE'])
 
         case request.env['HTTP_X_GITHUB_EVENT']
             when "pull_request"
                 if @payload["action"] == "opened"
                     logger.debug "WHC Received: pull_request[opened]"
+                    WebhookHelper.pr_opened(@payload)
                 elsif @payload["action"] == "synchronized"
                     logger.debug "WHC Received: pull_request[synchronized]"
+                    WebhookHelper.pr_synchronized(@payload)
                 elsif @payload["action"] == "closed"
                     logger.debug "WHC Received: pull_request[closed]"
+                    WebhookHelper.pr_closed(@payload)
                 elsif @payload["action"] == "reopened"
                     logger.debug "WHC Received: pull_request[reopened]"
+                    WebhookHelper.pr_reopened(@payload)
                 else
                     logger.debug "WHC Received: pull_request[Unknown action]"
                 end
             when "issue_comment"
                 logger.debug "WHC Received: issue_comment"
+                WebhookHelper.issue_comment(@payload)
             when "ping"
                 logger.debug "WHC Received: ping"
+                WebhookHelper.ping(@payload)
                 # Send initial status message so Protected Branch can be setup
             else
                 logger.debug "WHC Received: Unknown Event"
@@ -33,11 +46,5 @@ class WebhookController < ApplicationController
         # For now don't send anything in body of message.
         # In future might add status message here
         render plain: "Received #{request.env['HTTP_X_GITHUB_EVENT']} Event"
-    end
-
-    def verify_signature(payload_body)
-        # TODO: Create Secret Key for each repo. Store in DB
-        signature = 'sha1=' + OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha1'), ENV['WEBHOOK_SECRET_KEY'], payload_body)
-        return halt 500, "Signatures didn't match!" unless Rack::Utils.secure_compare(signature, request.env['HTTP_X_HUB_SIGNATURE'])
     end
 end

--- a/app/helpers/webhook_helper.rb
+++ b/app/helpers/webhook_helper.rb
@@ -1,2 +1,25 @@
 module WebhookHelper
+    def self.verify_signature(key, payload_body, gh_signature)
+        signature = 'sha1=' + OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha1'), key, payload_body)
+        return render(status: :bad_request, plain: "Signatures didn't match!") \
+            unless Rack::Utils.secure_compare(signature, gh_signature)
+    end
+
+    def self.pr_opened(payload)
+    end
+
+    def self.pr_synchronized(payload)
+    end
+
+    def self.pr_closed(payload)
+    end
+
+    def self.pr_reopened(payload)
+    end
+
+    def self.issue_comment(payload)
+    end
+
+    def self.ping(payload)
+    end
 end


### PR DESCRIPTION
Setup environment to do travis-ci testing on all commits.

Current settings:
```yaml
language: ruby
rvm:
    - 2.2
services:
    - postgresql
before_script:
    - bundle exec rake db:setup
sudo: false
notifications:
  email: false
```
Right now travis doesn't support ruby 2.3 for testing so set to highest for now - 2.2.
Disable all email notifications. Can always change later, but figure don't annoy us to much right now.

One thing to look into for improving test speed is the bundle install command. Takes the majority of test time right now.

Resolves #22.